### PR TITLE
fix duplicate key error

### DIFF
--- a/aduser/db/__init__.py
+++ b/aduser/db/__init__.py
@@ -18,7 +18,7 @@ def configure_db():
 
     # User identification collection
     user_collection = yield get_collection('user')
-    yield user_collection.create_index(suid_idx, unique=True)
+    yield user_collection.create_index(suid_idx + tid_idx, unique=True)
     yield user_collection.create_index(tid_idx)
 
     yield get_collection('pixel').create_index(suid_idx)


### PR DESCRIPTION
Fix DuplicateKeyError(error.get("errmsg"), 11000, error) from logs.